### PR TITLE
stagefright: add changes related to high-framerates in CameraSource

### DIFF
--- a/media/libmediaplayerservice/StagefrightRecorder.cpp
+++ b/media/libmediaplayerservice/StagefrightRecorder.cpp
@@ -1592,7 +1592,7 @@ status_t StagefrightRecorder::setupCameraSource(
     Size videoSize;
     videoSize.width = mVideoWidth;
     videoSize.height = mVideoHeight;
-    if (mCaptureFpsEnable) {
+    if (mCaptureFpsEnable && mCaptureFps != mFrameRate) {
         if (!(mCaptureFps > 0.)) {
             ALOGE("Invalid mCaptureFps value: %lf", mCaptureFps);
             return BAD_VALUE;
@@ -1740,6 +1740,7 @@ status_t StagefrightRecorder::setupVideoEncoder(
             preferBFrames = false;
             tsLayers = 2; // use at least two layers as resulting video will likely be sped up
         } else if (mCaptureFps > maxPlaybackFps) { // slow-mo
+            format->setInt32("high-frame-rate", 1);
             maxPlaybackFps = mCaptureFps; // assume video will be played back at full capture speed
             preferBFrames = false;
         }
@@ -1995,7 +1996,7 @@ status_t StagefrightRecorder::resume() {
 
     // 30 ms buffer to avoid timestamp overlap
     mTotalPausedDurationUs +=
-        resumeStartTimeUs - mPauseStartTimeUs -
+        (systemTime() / 1000) - mPauseStartTimeUs -
         (30000 * (mCaptureFpsEnable ? (mCaptureFps / mFrameRate):1));
       }
     double timeOffset = -mTotalPausedDurationUs;

--- a/media/libstagefright/CameraSource.cpp
+++ b/media/libstagefright/CameraSource.cpp
@@ -344,8 +344,8 @@ status_t CameraSource::isCameraColorFormatSupported(
 
 static int32_t getHighSpeedFrameRate(const CameraParameters& params) {
     const char* hsr = params.get("video-hsr");
-    int32_t rate = (hsr != NULL && strncmp(hsr, "off", 3)) ? atoi(hsr) : 0;
-    return rate > 240 ? 240 : rate;
+    int32_t rate = (hsr != NULL && strncmp(hsr, "off", 3)) ? strtol(hsr, NULL, 10) : 0;
+    return std::min(rate, 120);
 }
 
 /*
@@ -395,7 +395,7 @@ status_t CameraSource::configureCamera(
     }
 
     if (frameRate != -1) {
-        CHECK(frameRate > 0 && frameRate <= 120);
+        CHECK(frameRate > 0 && frameRate <= 240);
         const char* supportedFrameRates =
                 params->get(CameraParameters::KEY_SUPPORTED_PREVIEW_FRAME_RATES);
         CHECK(supportedFrameRates != NULL);


### PR DESCRIPTION
Below changes are squashed with this change

Stagefright: Allow setting high-framerates in CameraSource
ChangeId: If66211dd81b2a08d4df4c6f23e87304e9e7013f4

Stagefright: Allow setting of high-framerates in CameraSource for HSR
ChangeId: I30cb3b656570de1b615d55c20c0b4f98ae6e0c12

Stagefright: Create CameraSource for HSR
ChangeId: I7f420f5b15fb3c05bb7f918430ca9b7a630ed18e

Stagefright: Do not skip frames in time-lapse-source for high-speed
ChangeId: I8420e44ab96484f0d6301c366a24eefc8efeaf0f

media : Changing time stamp manipulation in HFR recording.
ChangeId: I98cdb14bb2b9c86013df9b2c8f2e558f184b633e

Change-Id: I2aff66f22201466cf08f608e87986fd4508d6086
media: Modify timestamps for HFR use case
ChangeId: I3faf7294f743b1031ccc6624c3348f7e12b339b8
Signed-off-by: Srijith2001 <srijith8603>